### PR TITLE
Dataset for split dataset

### DIFF
--- a/DTOs/MainApp.BL/DatasetDTOs/ImageAnnotationDTO.cs
+++ b/DTOs/MainApp.BL/DatasetDTOs/ImageAnnotationDTO.cs
@@ -19,9 +19,9 @@ namespace DTOs.MainApp.BL.DatasetDTOs
 
         public string GeoJson { get => GeoJsonHelpers.GeometryToGeoJson(Geom); }
 
-        public Dictionary<int, int>? TopLeftBottomRight { get => GeoJsonHelpers.GeometryBBoxToTopLeftBottomRight(Geom); }
+        //public Dictionary<int, int>? TopLeftBottomRight { get => GeoJsonHelpers.GeometryBBoxToTopLeftBottomRight(Geom); }
 
-        public Dictionary<int, int>? TopLeftWidthHeight { get => GeoJsonHelpers.GeometryBBoxToTopLeftWidthHeight(Geom); }
+        //public Dictionary<int, int>? TopLeftWidthHeight { get => GeoJsonHelpers.GeometryBBoxToTopLeftWidthHeight(Geom); }
 
         public bool IsEnabled { get; init; } = false;
 

--- a/MainApp.MVC/Areas/IntranetPortal/Views/Datasets/Edit.cshtml
+++ b/MainApp.MVC/Areas/IntranetPortal/Views/Datasets/Edit.cshtml
@@ -979,16 +979,14 @@
         }
 
         function startExport() {
-            const toggleAllImages = document.getElementById('toggleAllImages').checked; // "All Images" or "Enabled Images"
-            const asSplit = $('#splitDataset').is(':checked'); // "Export as Split Dataset"
+            const toggleAllImages = document.getElementById('toggleAllImages').checked;
+            const asSplit = $('#toggleExportStatus').is(':checked');
             let exportOption = '';
 
-            // If "All Images" is selected, get the image type (Annotated/Unannotated)
             if (toggleAllImages) {
-                const imageType = document.getElementById('imageTypeDropdown').value; // Get dropdown value (Annotated/Unannotated)
-                exportOption = imageType; // Set exportOption to either "AnnotatedImages" or "UnannotatedImages"
+                const imageType = document.getElementById('imageTypeDropdown').value;
+                exportOption = imageType;
             } else {
-                // If "Enabled Images" is selected, set exportOption to "EnabledImages"
                 exportOption = 'EnabledImages';
             }
 

--- a/MainApp.MVC/Areas/IntranetPortal/Views/Datasets/Edit.cshtml
+++ b/MainApp.MVC/Areas/IntranetPortal/Views/Datasets/Edit.cshtml
@@ -43,10 +43,21 @@
                         <div class="card-tools">
                             @if (User.HasAuthClaim(SD.AuthClaims.AddDatasetClass))
                             {
-                                <button class="btn btn-sm btn-outline-primary"
-                                        data-toggle="modal" data-target="#addNewDatasetClassModal">
-                                    @DbResHtml.T("Add Class", "Resources")
-                                </button>
+                                if (Model.CurrentDataset.IsPublished)
+                                {
+                                     <button class="btn btn-sm btn-outline-primary"
+                                            disabled>
+                                        @DbResHtml.T("Add Class", "Resources")
+                                    </button>                                    
+                                }
+                                else
+                                {
+                                    <button class="btn btn-sm btn-outline-primary"
+                                            data-toggle="modal" data-target="#addNewDatasetClassModal">
+                                        @DbResHtml.T("Add Class", "Resources")
+                                    </button>
+                                }
+
                             }
                             <button type="button" class="btn btn-tool" data-card-widget="collapse" title="Collapse">
                                 <i class="fas fa-minus"></i>
@@ -82,7 +93,14 @@
                             {
                                 @if (User.HasAuthClaim(SD.AuthClaims.ChooseDatasetClassType))
                                 {
+                                    if (Model.CurrentDataset.IsPublished)
+                                    {
+                                        <button class="mt-3 mr-3 float-right btn btn-sm bg-gradient-primary" disabled>@DbResHtml.T("Choose Class Type", "Resources")</button>
+                                    }
+                                    else
+                                    {
                                     <button class="mt-3 mr-3 float-right btn btn-sm bg-gradient-primary" data-toggle="modal" data-target="#chooseDatasetClassTypeModal">@DbResHtml.T("Choose Class Type", "Resources")</button>
+                                    }
                                 }
                             }
                             else
@@ -117,9 +135,15 @@
                                                 <td class="text-right py-0 align-middle">
                                                     @if (User.HasAuthClaim(SD.AuthClaims.DeleteDatasetClass))
                                                     {
+                                                        if (Model.CurrentDataset.IsPublished)
+                                                        {
+                                                        }
+                                                        else
+                                                        {
                                                         <div class="btn-group btn-group-sm">
                                                             <a class="btn btn-outline-danger" data-toggle="modal" data-target="#deleteDatasetClassModal_@item.Id" title="@DbResHtml.T("Delete Class", "Resources")"><i class="fas fa-trash"></i></a>
                                                         </div>
+                                                        }
                                                     }
                                                 </td>
                                             </tr>
@@ -134,10 +158,19 @@
                 </div>
                 @if (User.HasAuthClaim(SD.AuthClaims.AddDatasetImage))
                 {
+                    if (Model.CurrentDataset.IsPublished)
+                    {
+                        <button type="submit" class="btn btn-success btn-block mb-3 sticky-top" disabled>
+                            <span>@DbResHtml.T("Add new dataset image", "Resources")</span>
+                            <i class="fas fa-image ml-1"></i>
+                        </button>
+                    }
+                    else{
                     <button type="submit" class="btn btn-success btn-block mb-3 sticky-top" data-toggle="modal" data-target="#addNewDatasetImageModal">
                         <span>@DbResHtml.T("Add new dataset image", "Resources")</span>
                         <i class="fas fa-image ml-1"></i>
                     </button>
+                    }
                 }
                 <!-- General Statistics -->
                 <div class="card card-light">
@@ -208,10 +241,20 @@
                 <!-- Publish Btn -->
                 @if (User.HasAuthClaim(SD.AuthClaims.PublishDataset))
                 {
+                    if (Model.CurrentDataset.IsPublished)
+                    {
+                    <button class="btn btn-outline-primary btn-block" disabled>
+                        @DbResHtml.T("Publish Dataset", "Resources")
+                        <i class=" mx-1 fas fa-upload"></i>
+                    </button>                        
+                    }
+                    else
+                    {
                     <button class="btn btn-outline-primary btn-block" data-toggle="modal" data-target="#publishDatasetModal">
                         @DbResHtml.T("Publish Dataset", "Resources")
                         <i class=" mx-1 fas fa-upload"></i>
                     </button>
+                    }
                 }
                 <!-- Export Btn TODO: Change Auth Claim-->
 @*                 @if (User.HasAuthClaim(SD.AuthClaims.PublishDataset))
@@ -337,9 +380,19 @@
                                         <h5 class="text-center text-white d-inline pl-3">@item.Name</h5>
                                         @if (User.HasAuthClaim(SD.AuthClaims.DeleteDatasetImage))
                                         {
-                                            <button onclick="deleteDatasetImage('@item.Id','@item.FileName')" type="button" class="close text-white float-right" aria-label="Close">
-                                                <span aria-hidden="true" class="pr-1">&times;</span>
-                                            </button>
+                                            if (Model.CurrentDataset.IsPublished)
+                                            {
+                                                <button type="button" class="close text-white float-right" aria-label="Close" disabled>
+                                                    <span aria-hidden="true" readonly class="pr-1">&times;</span>
+                                                </button>
+
+                                            }
+                                            else
+                                            {
+                                                <button onclick="deleteDatasetImage('@item.Id','@item.FileName')" type="button" class="close text-white float-right" aria-label="Close">
+                                                    <span aria-hidden="true" class="pr-1">&times;</span>
+                                                </button>
+                                            }
                                         }
                                     </div>
                                     <div class="card-body border border-top-0 d-flex flex-column align-items-center @cardBodyClass">
@@ -347,11 +400,26 @@
                                             <img id="@item.Id" class="rounded" src="@Url.Content("~" + thumbPath)" />
                                             @if (User.HasAuthClaim(SD.AuthClaims.EditDatasetImage))
                                             {
-                                                <input id="@($"{item.Id}_editImage")" class="editImage btn btn-xs bg-gradient-warning text-white" type="button" value="Edit image" data-toggle="modal" data-target="#editDatasetImageModal_@item.Id" />
+                                                if (Model.CurrentDataset.IsPublished)
+                                                {
+                                                    <input class="editImage btn btn-xs bg-gradient-warning text-white" type="button" value="Edit image" disabled readonly/>
+                                                    
+                                                }
+                                                else
+                                                {
+                                                    <input id="@($"{item.Id}_editImage")" class="editImage btn btn-xs bg-gradient-warning text-white" type="button" value="Edit image" data-toggle="modal" data-target="#editDatasetImageModal_@item.Id" />
+                                                }
                                             }
                                             @if (User.HasAuthClaim(SD.AuthClaims.EditDatasetImageAnnotations))
                                             {
-                                                <a id="@($"{item.Id}_editImageAnnotation")" href="@Url.Action("Annotate", "Annotations", new { Area = "IntranetPortal", datasetImageId = item.Id })" class="editAnnotation btn btn-xs bg-gradient-orange text-white">Edit annotations</a>
+                                                if (Model.CurrentDataset.IsPublished)
+                                                {
+                                                    <input class="editAnnotation btn btn-xs bg-gradient-orange text-white" type="button" value="Edit annotations" disabled readonly/>
+                                                }
+                                                else
+                                                {
+                                                    <a id="@($"{item.Id}_editImageAnnotation")" href="@Url.Action("Annotate", "Annotations", new { Area = "IntranetPortal", datasetImageId = item.Id })" class="editAnnotation btn btn-xs bg-gradient-orange text-white">Edit annotations</a>
+                                                }
                                             }
                                             <input type="hidden" id="annotationStatus_@item.Id" value="@isAnnotated" />
 
@@ -992,6 +1060,13 @@
 
             $('#exportModal').modal('hide');
 
+            Swal.fire({
+                icon: 'info',
+                text: 'Exporting dataset, please wait...',
+                allowOutsideClick: false,
+                showConfirmButton: false
+            });
+
             exportDatasetAnnotationsToCOCO(exportOption, asSplit);
         }
 
@@ -1006,17 +1081,24 @@
                     responseType: 'blob'
                 },
                 success: function (data, status, xhr) {
-                    const filename = xhr.getResponseHeader('Content-Disposition')?.split('filename=')[1]?.replace(/"/g, '') || 'dataset.zip';
-                    const blob = new Blob([data], { type: 'application/zip' });
+                    Swal.close(); 
 
+                    const contentDisposition = xhr.getResponseHeader('Content-Disposition');
+                    const downloadDisposition = xhr.getResponseHeader('Download-Disposition');
+                    const fileGuid = contentDisposition?.match(/[\w-]+\.zip/)?.[0] || '';
+                    const fileName = downloadDisposition || 'default-filename.zip';
+
+                    const blob = new Blob([data], { type: 'application/zip' });
                     const url = URL.createObjectURL(blob);
                     const a = document.createElement('a');
                     a.href = url;
-                    a.download = filename;
+                    a.download = fileName;
                     document.body.appendChild(a);
                     a.click();
                     document.body.removeChild(a);
                     URL.revokeObjectURL(url);
+
+                    $.post('@Url.Action("CleanupTempFilesFromExportDataset", "Datasets", new { area = "IntranetPortal" })', { fileGuid: fileGuid });
 
                     Swal.fire({
                         text: 'Download initiated successfully!',
@@ -1025,6 +1107,8 @@
                     });
                 },
                 error: function (req, status, error) {
+                    Swal.close(); 
+
                     Swal.fire({
                         text: 'An error occurred while processing your request.',
                         icon: 'error',
@@ -1035,11 +1119,13 @@
         }
 
 
+
+
         function handleSwitchChange() {
-            var toggleAllImages = document.getElementById('toggleAllImages').checked;
-            var imageTypeDropdown = document.getElementById('imageTypeDropdown');
-            var allImagesLabel = document.getElementById('allImagesLabel');
-            var enabledImagesLabel = document.getElementById('enabledImagesLabel');
+            const toggleAllImages = document.getElementById('toggleAllImages').checked;
+            const imageTypeDropdown = document.getElementById('imageTypeDropdown');
+            const allImagesLabel = document.getElementById('allImagesLabel');
+            const enabledImagesLabel = document.getElementById('enabledImagesLabel');
 
             if (toggleAllImages) {
                 imageTypeDropdown.disabled = false;
@@ -1068,10 +1154,24 @@
                 toggleLabel.classList.remove('text-success');
             }
         }
+        function initializeExportOptions() {
+            const toggleAllImages = document.getElementById('toggleAllImages');
+            const imageTypeDropdown = document.getElementById('imageTypeDropdown');
+            const allImagesLabel = document.getElementById('allImagesLabel');
+            const enabledImagesLabel = document.getElementById('enabledImagesLabel');
 
+            toggleAllImages.checked = false;
+            imageTypeDropdown.disabled = true;
+            allImagesLabel.style.display = "none";
+            enabledImagesLabel.style.display = "inline";
+        }
 
-        handleSwitchChange();
+        $(document).ready(function () {
+            initializeExportOptions();
+                    handleSwitchChange();
         updateImageStatusLabels();
+        });
+
     </script>
 }
 
@@ -1338,26 +1438,25 @@
                 <div class="modal-body">
                     <form id="exportConfigForm">
                         <h5 class="mb-4">Export options for dataset</h5>
-
-                        <div class="form-group row mb-3">
-                            <label class="col-12 col-md-4 col-form-label">Export Option</label>
-                            <div class="col-12 col-md-8 d-flex justify-content-center align-items-center">
-                                <div class="custom-control custom-switch">
-                                    <input type="checkbox"
-                                           class="custom-control-input"
-                                           id="toggleAllImages"
-                                           onchange="handleSwitchChange()">
-                                    <label class="custom-control-label" for="toggleAllImages">
-                                        <span id="allImagesLabel">
-                                            <i class="fas fa-images"></i> All Images
-                                        </span>
-                                        <span id="enabledImagesLabel" style="display: none;">
-                                            <i class="fas fa-image"></i> Enabled Images
-                                        </span>
-                                    </label>
+                            <div class="form-group row mb-3">
+                                <label class="col-12 col-md-4 col-form-label">Export Option</label>
+                                <div class="col-12 col-md-8 d-flex justify-content-center align-items-center">
+                                    <div class="custom-control custom-switch">
+                                        <input type="checkbox"
+                                               class="custom-control-input"
+                                               id="toggleAllImages"
+                                               onchange="handleSwitchChange()">
+                                        <label class="custom-control-label" for="toggleAllImages">
+                                            <span id="allImagesLabel" style="display: none;">
+                                                <i class="fas fa-images"></i> All Images
+                                            </span>
+                                            <span id="enabledImagesLabel">
+                                                <i class="fas fa-image"></i> Enabled Images
+                                            </span>
+                                        </label>
+                                    </div>
                                 </div>
                             </div>
-                        </div>
                         <div class="form-group row mb-3">
                             <label class="col-12 col-md-4 col-form-label">Image Type</label>
                             <div class="col-12 col-md-8">

--- a/MainApp.MVC/Areas/IntranetPortal/Views/Datasets/Index.cshtml
+++ b/MainApp.MVC/Areas/IntranetPortal/Views/Datasets/Index.cshtml
@@ -8,44 +8,10 @@
 @{
     ViewData["Title"] = @DbResHtml.T("Datasets list", "Resources");
 }
+@section Styles {
+    <link rel="stylesheet" href="~/css/Datasets/indexDataset.css">
+}
 
-<style>
-    /* Hide the actual file input */
-     #importDatasetFile {
-         display: none;
-     }
-
-    /* Customize the appearance of the file label button */
-    .custom-file-label::after {
-        background-color: #007bff;
-        color: white;
-        padding: 0.375rem 0.75rem;
-        border-radius: 0.25rem;
-        border: 1px solid #007bff;
-        cursor: pointer;
-    }
-
-    /* Additional custom styling if needed */
-    .custom-file-label {
-        cursor: pointer;
-    }
-
-    .progress {
-        height: 1.5rem;
-        border-radius: 0.5rem;
-        background-color: #f2f2f2;
-    }
-
-    .progress-bar {
-        background-color: #007bff;
-        transition: width 0.4s ease;
-        border-radius: 0.5rem;
-        font-weight: bold;
-        color: white;
-        text-align: center;
-        box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-    }
-</style>
 <div class="content-header bg-gradient-white border-bottom mb-4">
     <div class="container-fluid">
         <div class="row">
@@ -132,7 +98,7 @@
                                         <td>@item.UpdatedBy?.UserName</td>
                                         <td>@item.UpdatedOn?.ToString("dd.MM.yyyy")</td>
                                         <td>
-                                            @if (User.HasAuthClaim(SD.AuthClaims.ManageDataset) && item.IsPublished == false)
+                                            @if (User.HasAuthClaim(SD.AuthClaims.ManageDataset))
                                             {
                                                 <a asp-controller="Datasets" asp-action="Edit" asp-route-datasetId="@item.Id" class="mb-1 btn bg-gradient-warning text-white btn-xs" title="@DbResHtml.T("Manage dataset", "Resources")">
                                                     <i class="far fa-edit"></i>
@@ -142,7 +108,7 @@
                                             {
                                                 @if (User.HasAuthClaim(SD.AuthClaims.ManageDataset) && item.IsPublished == true)
                                                 {
-                                                    <button class="ml-5 mb-1 btn bg-gradient-danger btn-xs" data-toggle="modal" data-target="#deleteDatasetModal_@item.Id" title="@DbResHtml.T("Delete dataset", "Resources")">
+                                                    <button class="mx-1 mb-1 btn bg-gradient-danger btn-xs" data-toggle="modal" data-target="#deleteDatasetModal_@item.Id" title="@DbResHtml.T("Delete dataset", "Resources")">
                                                         <i class="fas fa-trash"></i>
                                                     </button>
                                                 }
@@ -225,6 +191,7 @@
                 $(".export-to-excel-button").click();
             });
         });
+
         
         function closeViewParentChildrenDatasetsModal() {
             $("#viewParentChildrenDatasetModal").hide();
@@ -366,6 +333,12 @@
             });
         }
 
+        $(document).ready(function () {
+            $('#importDatasetFile').on('change', function () {
+                var fileName = $(this).val().split('\\').pop();
+                $(this).next('.custom-file-label').html(fileName || 'Choose file');
+            });
+        });
 
         function importNewDatasetConfirmed() {
             var datasetFile = $('#importDatasetFile')[0].files[0];
@@ -393,9 +366,11 @@
             formData.append("datasetName", datasetName);
             formData.append("allowUnannotatedImages", allowUnannotatedImages);
 
-            $('#importNewDatasetModal').modal({
-                backdrop: 'static',
-                keyboard: false 
+            Swal.fire({
+                icon: "warning",
+                text: "Uploading/Importing in progress...",
+                allowOutsideClick: false,
+                showConfirmButton: false
             });
 
             $('#importNewDatasetModal input, #importNewDatasetModal button').prop('disabled', true);
@@ -407,20 +382,8 @@
                 data: formData,
                 contentType: false,
                 processData: false,
-                xhr: function () {
-                    var xhr = new window.XMLHttpRequest();
-                    xhr.upload.addEventListener("progress", function (evt) {
-                        if (evt.lengthComputable) {
-                            var percentComplete = evt.loaded / evt.total;
-                            var percentCompleteRounded = Math.round(percentComplete * 100);
-                            $('#importProgressBar').css('width', percentCompleteRounded + '%');
-                            $('#importProgressBar').text(percentCompleteRounded + '%');
-                        }
-                    }, false);
-                    return xhr;
-                },
                 success: function (data) {
-                    $('#importProgressBar').css('width', '0%').text('0%');
+                    Swal.close();
                     if (data.responseError) {
                         Swal.fire({
                             text: `${data.responseError.value}`,
@@ -441,7 +404,7 @@
                     }
                 },
                 error: function (req, status, error) {
-                    $('#importProgressBar').css('width', '0%').text('0%');
+                    Swal.close();
                     Swal.fire({
                         text: '@DbResHtml.T("Error occurred", "Resources")',
                         icon: "error"
@@ -453,7 +416,6 @@
                 }
             });
         }
-
 
 
         function deleteDatasetConfirmed(datasetId) {
@@ -595,8 +557,8 @@
                     </div>
                     <label class="form-control-label mt-3">@DbResHtml.T("Import dataset", "Resources")</label>
                     <div class="custom-file">
-                        <label class="custom-file-label" for="importDatasetFile">@DbResHtml.T("Choose file", "Resources")</label>
                         <input type="file" name="DatasetFile" class="custom-file-input" id="importDatasetFile" accept=".zip" required>
+                        <label class="custom-file-label" for="importDatasetFile">Choose file</label>
                     </div>
                     <div class="form-group">
                         <div class="form-check mt-3">

--- a/MainApp.MVC/wwwroot/css/Datasets/editDataset.css
+++ b/MainApp.MVC/wwwroot/css/Datasets/editDataset.css
@@ -28,7 +28,10 @@ div.show-image {
             top: 3px;
             left: 4px;           
         }
-
+        div.show-image input.editAnnotation {
+            top: 3px;
+            left: 50%;
+        }
         div.show-image a.editAnnotation {
             top: 3px;
             left: 50%;
@@ -37,3 +40,9 @@ div.show-image {
 .pagination-container ul{
    justify-content:center;
 }
+.disabled-link {
+    pointer-events: none;
+    cursor: not-allowed; 
+    opacity: 0.6;
+}
+

--- a/MainApp.MVC/wwwroot/css/Datasets/indexDataset.css
+++ b/MainApp.MVC/wwwroot/css/Datasets/indexDataset.css
@@ -1,0 +1,32 @@
+﻿#importDatasetFile {
+    display: none;
+}
+
+.custom-file-label::after {
+    background-color: #007bff;
+    color: white;
+    padding: 0.375rem 0.75rem;
+    border-radius: 0.25rem;
+    border: 1px solid #007bff;
+    cursor: pointer;
+}
+
+.custom-file-label {
+    cursor: pointer;
+}
+
+.progress {
+    height: 1.5rem;
+    border-radius: 0.5rem;
+    background-color: #f2f2f2;
+}
+
+.progress-bar {
+    background-color: #007bff;
+    transition: width 0.4s ease;
+    border-radius: 0.5rem;
+    font-weight: bold;
+    color: white;
+    text-align: center;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+}

--- a/Tests/DTOsTests/MainAppBL/DatasetDTOsTests/ImageAnnotationDTOTests.cs
+++ b/Tests/DTOsTests/MainAppBL/DatasetDTOsTests/ImageAnnotationDTOTests.cs
@@ -1,12 +1,7 @@
-﻿using DTOs.MainApp.BL.DatasetDTOs;
+﻿using DTOs.Helpers;
 using DTOs.MainApp.BL;
+using DTOs.MainApp.BL.DatasetDTOs;
 using NetTopologySuite.Geometries;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using DTOs.Helpers;
 
 namespace Tests.DTOsTests.MainAppBL.DatasetDTOsTests
 {
@@ -119,49 +114,49 @@ namespace Tests.DTOsTests.MainAppBL.DatasetDTOsTests
             Assert.Equal(expectedGeoJson, actualGeoJson);
         }
 
-        [Fact]
-        public void ImageAnnotationDTO_TopLeftBottomRight_ShouldReturnExpectedDictionary()
-        {
-            // Arrange
-            var geom = new Polygon(new LinearRing(new[]
-            {
-                new Coordinate(0, 0),
-                new Coordinate(1, 0),
-                new Coordinate(1, 1),
-                new Coordinate(0, 1),
-                new Coordinate(0, 0)
-            }));
-            var expectedDictionary = GeoJsonHelpers.GeometryBBoxToTopLeftBottomRight(geom);
+        //[Fact]
+        //public void ImageAnnotationDTO_TopLeftBottomRight_ShouldReturnExpectedDictionary()
+        //{
+        //    // Arrange
+        //    var geom = new Polygon(new LinearRing(new[]
+        //    {
+        //        new Coordinate(0, 0),
+        //        new Coordinate(1, 0),
+        //        new Coordinate(1, 1),
+        //        new Coordinate(0, 1),
+        //        new Coordinate(0, 0)
+        //    }));
+        //    var expectedDictionary = GeoJsonHelpers.GeometryBBoxToTopLeftBottomRight(geom);
 
-            // Act
-            var dto = new ImageAnnotationDTO { Geom = geom };
-            var actualDictionary = dto.TopLeftBottomRight;
+        //    // Act
+        //    var dto = new ImageAnnotationDTO { Geom = geom };
+        //    var actualDictionary = dto.TopLeftBottomRight;
 
-            // Assert
-            Assert.Equal(expectedDictionary, actualDictionary);
-        }
+        //    // Assert
+        //    Assert.Equal(expectedDictionary, actualDictionary);
+        //}
 
-        [Fact]
-        public void ImageAnnotationDTO_TopLeftWidthHeight_ShouldReturnExpectedDictionary()
-        {
-            // Arrange
-            var geom = new Polygon(new LinearRing(new[]
-            {
-                new Coordinate(0, 0),
-                new Coordinate(1, 0),
-                new Coordinate(1, 1),
-                new Coordinate(0, 1),
-                new Coordinate(0, 0)
-            }));
-            var expectedDictionary = GeoJsonHelpers.GeometryBBoxToTopLeftWidthHeight(geom);
+        //[Fact]
+        //public void ImageAnnotationDTO_TopLeftWidthHeight_ShouldReturnExpectedDictionary()
+        //{
+        //    // Arrange
+        //    var geom = new Polygon(new LinearRing(new[]
+        //    {
+        //        new Coordinate(0, 0),
+        //        new Coordinate(1, 0),
+        //        new Coordinate(1, 1),
+        //        new Coordinate(0, 1),
+        //        new Coordinate(0, 0)
+        //    }));
+        //    var expectedDictionary = GeoJsonHelpers.GeometryBBoxToTopLeftWidthHeight(geom);
 
-            // Act
-            var dto = new ImageAnnotationDTO { Geom = geom };
-            var actualDictionary = dto.TopLeftWidthHeight;
+        //    // Act
+        //    var dto = new ImageAnnotationDTO { Geom = geom };
+        //    var actualDictionary = dto.TopLeftWidthHeight;
 
-            // Assert
-            Assert.Equal(expectedDictionary, actualDictionary);
-        }
+        //    // Assert
+        //    Assert.Equal(expectedDictionary, actualDictionary);
+        //}
 
     }
 }


### PR DESCRIPTION
A new endpoint is added that deletes the temp files for exporting the dataset on success of the upload. 
Fixing the filter for IsAnnotated images in the Edit dataset view.
Added spinners in the Import and Export dataset instead of the loader.
Published dataset can be open for edit where only export of the dataset is available all of the other functionalities are disabled. This is for purpose to view the images of a published dataset.